### PR TITLE
fix: add missing comma

### DIFF
--- a/src/content/docs/integrations/storybook.mdx
+++ b/src/content/docs/integrations/storybook.mdx
@@ -106,7 +106,7 @@ const meta: Meta<MyElement> = {
   component: "my-element",
   args,
   argTypes,
-  render: (args) => template(args)
+  render: (args) => template(args),
   parameters: {
     actions: {
       handles: events,


### PR DESCRIPTION
Just noticed a missing comma while copy and pasting from the storybook docs :D 